### PR TITLE
feat: multiple game master, adjust unique user, add user history in game detail

### DIFF
--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -111,6 +111,9 @@ var (
 	ErrUpdatingGame        = "Error updating game by code"
 	ErrCheckExistGameUsed  = "Error on checking game is used by other room or tournament"
 	ErrForbiddenDeleteGame = "Game cannot be deleted, because is used in another room or tournament"
+	ErrGettingGameAdmins   = "Error getting list game admin"
+	ErrScanningGameAdmins  = "Error scanning list game admin"
+	ErrSyncingGameAdmins   = "Error syncing game admin"
 
 	// Error for module game category
 	ErrAddingGameCategory   = "Error adding game category"

--- a/resources/migrations/000080_create_games_admins_table.down.sql
+++ b/resources/migrations/000080_create_games_admins_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS games_admins;

--- a/resources/migrations/000080_create_games_admins_table.up.sql
+++ b/resources/migrations/000080_create_games_admins_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS games_admins (
+    game_id INTEGER REFERENCES games(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    admin_id INTEGER REFERENCES admins(id) ON DELETE CASCADE ON UPDATE CASCADE,
+
+    PRIMARY KEY(game_id, admin_id)
+);

--- a/services/api/model/m_game.go
+++ b/services/api/model/m_game.go
@@ -72,9 +72,8 @@ func (c *Contract) GetGameList(db *pgxpool.Pool, ctx context.Context, param requ
 		paramQuery []interface{}
 		totalData  int
 
-		query = `WITH games_popularity AS (
-			SELECT game_id, COUNT(DISTINCT user_id) as number_of_popularity
-			FROM (
+		query = `WITH 
+		unique_participants AS (
 				SELECT DISTINCT r.game_id, rp.user_id
 				FROM rooms r 
 				INNER JOIN rooms_participants rp ON r.id = rp.room_id AND rp.status = 'active'
@@ -82,7 +81,17 @@ func (c *Contract) GetGameList(db *pgxpool.Pool, ctx context.Context, param requ
 				SELECT DISTINCT t.game_id, tp.user_id
 				FROM tournaments t
 				INNER JOIN tournament_participants tp ON t.id = tp.tournament_id AND tp.status = 'active'
-			) unique_participants
+				UNION
+				SELECT DISTINCT game_id, user_id FROM users_game_collections
+		),		
+		games_popularity AS (
+			SELECT game_id, COUNT(DISTINCT user_id) as number_of_popularity
+			FROM unique_participants
+			GROUP BY game_id
+		),
+		game_collections AS (
+			SELECT game_id, COUNT(distinct user_id) as number_of_collection
+			FROM (SELECT DISTINCT ugc.game_id, ugc.user_id FROM users_game_collections ugc) unique_collections 
 			GROUP BY game_id
 		)
 		SELECT 
@@ -104,9 +113,10 @@ func (c *Contract) GetGameList(db *pgxpool.Pool, ctx context.Context, param requ
 			a.admin_code, 
 			COALESCE(gc.categories, '[]'::json) as categories,
 			c.city AS location, 
-			COALESCE(gp.number_of_popularity, 0) AS number_of_popularity
+			COALESCE(gp.number_of_popularity, 0) + coalesce(gcols.number_of_collection, 0) AS number_of_popularity
 		FROM games g
 		LEFT JOIN games_popularity gp ON gp.game_id = g.id
+		LEFT JOIN game_collections gcols on gcols.game_id = g.id
 		LEFT JOIN cafes c ON c.id = g.cafe_id
 		LEFT JOIN admins a ON a.id = g.admin_id 
 		LEFT JOIN LATERAL (
@@ -252,9 +262,8 @@ func (c *Contract) GetGameByCode(db *pgxpool.Pool, ctx context.Context, code str
 	var (
 		err  error
 		data GameResp
-		sql  = `WITH games_popularity AS (
-			SELECT game_id, COUNT(DISTINCT user_id) as number_of_popularity
-			FROM (
+		sql  = `WITH 
+		unique_participants AS (
 				SELECT DISTINCT r.game_id, rp.user_id
 				FROM rooms r 
 				INNER JOIN rooms_participants rp ON r.id = rp.room_id AND rp.status = 'active'
@@ -262,13 +271,25 @@ func (c *Contract) GetGameByCode(db *pgxpool.Pool, ctx context.Context, code str
 				SELECT DISTINCT t.game_id, tp.user_id
 				FROM tournaments t
 				INNER JOIN tournament_participants tp ON t.id = tp.tournament_id AND tp.status = 'active'
-			) unique_participants
+				UNION
+				SELECT DISTINCT game_id, user_id
+				FROM users_game_collections
+		),		
+		games_popularity AS (
+			SELECT game_id, COUNT(DISTINCT user_id) as number_of_popularity
+			FROM unique_participants
+			GROUP BY game_id
+		),
+		game_collections AS (
+			SELECT game_id, COUNT(distinct user_id) as number_of_collection
+			FROM (SELECT DISTINCT ugc.game_id, ugc.user_id FROM users_game_collections ugc) unique_collections 
 			GROUP BY game_id
 		)
 		SELECT 
 			games.id, cafes.cafe_code, cafes.name as cafe_name, cafes.address as cafe_address,
 			games.game_code, games.game_type, games.name, games.image_url, 
-			games.collection_url, games.description, games.status, COALESCE(gp.number_of_popularity, 0),
+			games.collection_url, games.description, games.status, 
+			COALESCE(gp.number_of_popularity, 0) + coalesce(gcols.number_of_collection, 0) AS number_of_popularity,
 			games.duration, games.minimal_participant, games.maximum_participant,
 			games.difficulty, games.level, admins.admin_code,  
 			games_categories.categories,
@@ -277,6 +298,7 @@ func (c *Contract) GetGameByCode(db *pgxpool.Pool, ctx context.Context, code str
 			cafes.city AS location
 		FROM games 
 		LEFT JOIN games_popularity gp ON gp.game_id = games.id
+		LEFT JOIN game_collections gcols on gcols.game_id = games.id
 		LEFT JOIN cafes ON cafes.id = games.cafe_id
 		LEFT JOIN admins ON admins.id = games.admin_id 
 		LEFT JOIN (
@@ -356,15 +378,15 @@ func (c *Contract) GetGameByCode(db *pgxpool.Pool, ctx context.Context, code str
 	return data, nil
 }
 
-func (c *Contract) AddGame(tx pgx.Tx, ctx context.Context, cafeId int64, code, gameType, name, imgUrl, collectionUrl, desc, difficulty, status string, level float64, minimalParticipant, maximumParticipant, duration, adminId int64) (int64, error) {
+func (c *Contract) AddGame(tx pgx.Tx, ctx context.Context, cafeId int64, code, gameType, name, imgUrl, collectionUrl, desc, difficulty, status string, level float64, minimalParticipant, maximumParticipant, duration int64) (int64, error) {
 	var (
 		err error
 		id  int64
-		sql = `INSERT INTO games(cafe_id, game_code, game_type, name, image_url, collection_url, difficulty, level, description, status, minimal_participant, maximum_participant, duration, admin_id, created_date)
-	VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) RETURNING id`
+		sql = `INSERT INTO games(cafe_id, game_code, game_type, name, image_url, collection_url, difficulty, level, description, status, minimal_participant, maximum_participant, duration, created_date)
+	VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) RETURNING id`
 	)
 
-	err = tx.QueryRow(ctx, sql, cafeId, code, gameType, name, imgUrl, collectionUrl, difficulty, level, desc, status, minimalParticipant, maximumParticipant, duration, adminId, time.Now().In(time.UTC)).Scan(&id)
+	err = tx.QueryRow(ctx, sql, cafeId, code, gameType, name, imgUrl, collectionUrl, difficulty, level, desc, status, minimalParticipant, maximumParticipant, duration, time.Now().In(time.UTC)).Scan(&id)
 	if err != nil {
 		return id, c.errHandler("model.AddGame", err, utils.ErrAddingCafe)
 	}
@@ -372,16 +394,16 @@ func (c *Contract) AddGame(tx pgx.Tx, ctx context.Context, cafeId int64, code, g
 	return id, nil
 }
 
-func (c *Contract) UpdateGameByCode(tx pgx.Tx, ctx context.Context, cafeId int64, code, gameType, name, imgUrl, collectionUrl, desc, difficulty, status string, level float64, minimalParticipant, maximumParticipant, adminId, duration int64) error {
+func (c *Contract) UpdateGameByCode(tx pgx.Tx, ctx context.Context, cafeId int64, code, gameType, name, imgUrl, collectionUrl, desc, difficulty, status string, level float64, minimalParticipant, maximumParticipant, duration int64) error {
 	var (
 		err error
 		sql = `
 		UPDATE games 
-		SET cafe_id=$1, game_type=$2, name=$3, image_url=$4, collection_url=$5, description=$6, difficulty=$7, status=$8, level=$9, minimal_participant=$10, maximum_participant=$11, admin_id=$12, duration=$13, updated_date=$14
-		WHERE game_code=$15`
+		SET cafe_id=$1, game_type=$2, name=$3, image_url=$4, collection_url=$5, description=$6, difficulty=$7, status=$8, level=$9, minimal_participant=$10, maximum_participant=$11, duration=$12, updated_date=$13
+		WHERE game_code=$14`
 	)
 
-	_, err = tx.Exec(ctx, sql, cafeId, gameType, name, imgUrl, collectionUrl, desc, difficulty, status, level, minimalParticipant, maximumParticipant, adminId, duration, time.Now().In(time.UTC), code)
+	_, err = tx.Exec(ctx, sql, cafeId, gameType, name, imgUrl, collectionUrl, desc, difficulty, status, level, minimalParticipant, maximumParticipant, duration, time.Now().In(time.UTC), code)
 	if err != nil {
 		return c.errHandler("model.UpdateGameByCode", err, utils.ErrUpdatingGame)
 	}

--- a/services/api/model/m_game_admin.go
+++ b/services/api/model/m_game_admin.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"context"
+	"dots-api/lib/utils"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type (
+	GameAdminEnt struct {
+		GameId  int64 `json:"game_id"`
+		AdminId int64 `json:"admin_id"`
+	}
+)
+
+func (c *Contract) GetGameAdmins(db *pgxpool.Pool, ctx context.Context, gameId int64) ([]AdminEnt, error) {
+	var (
+		err  error
+		data []AdminEnt
+		sql  = `SELECT 
+		a.admin_code, a.email, a.name, a.username, a.status, a.image_url, a.phone_number, r.name as role
+		FROM admins a 
+		left join games_admins ga on ga.admin_id = a.id
+		left join roles r on r.id = a.role_id
+		WHERE ga.game_id = $1`
+	)
+
+	rows, err := db.Query(ctx, sql, gameId)
+	if err != nil {
+		return data, c.errHandler("model.GetGameAdmins", err, utils.ErrGettingGameAdmins)
+	}
+
+	for rows.Next() {
+		var admin AdminEnt
+		if err := rows.Scan(&admin.AdminCode, &admin.Email, &admin.Name, &admin.UserName, &admin.Status, &admin.ImageURL, &admin.PhoneNumber, &admin.Role); err != nil {
+			return data, c.errHandler("model.GetGameAdmins", err, utils.ErrScanningGameAdmins)
+		}
+		data = append(data, admin)
+	}
+
+	return data, nil
+}
+
+func (c *Contract) SyncGameAdmins(tx pgx.Tx, ctx context.Context, gameId int64, adminIds []int64) error {
+	var (
+		err    error
+		query  = `DELETE FROM games_admins WHERE game_id = $1`
+		query1 = `INSERT INTO games_admins(game_id, admin_id) SELECT $1, id FROM admins WHERE id = ANY($2)`
+	)
+
+	_, err = tx.Exec(ctx, query, gameId)
+	if err != nil {
+		return c.errHandler("model.SyncGameAdmins", err, utils.ErrSyncingGameAdmins)
+	}
+
+	if len(adminIds) == 0 {
+		return nil
+	}
+
+	_, err = tx.Exec(ctx, query1, gameId, adminIds)
+	if err != nil {
+		return c.errHandler("model.SyncGameAdmins", err, utils.ErrSyncingGameAdmins)
+	}
+
+	return nil
+}

--- a/services/api/model/m_user_game_history.go
+++ b/services/api/model/m_user_game_history.go
@@ -7,6 +7,7 @@ import (
 	"dots-api/services/api/request"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 )
@@ -29,11 +30,12 @@ type UserGameHistoryResp struct {
 }
 
 type UsersHavePlayedGameHistoryEnt struct {
-	GameId    sql.NullInt64  `db:"game_id"`
-	GameName  sql.NullString `db:"game_name"`
-	UserCode  sql.NullString `db:"user_code"`
-	UserName  sql.NullString `db:"username"`
-	UserImage sql.NullString `db:"user_image"`
+	GameId      sql.NullInt64  `db:"game_id"`
+	GameName    sql.NullString `db:"game_name"`
+	UserCode    sql.NullString `db:"user_code"`
+	UserName    sql.NullString `db:"username"`
+	UserImage   sql.NullString `db:"user_image"`
+	CreatedDate time.Time      `db:"created_date"`
 }
 
 func (c *Contract) GetUserGameHistories(db *pgxpool.Pool, ctx context.Context, userCode string, param request.UserGameHistoryParam) ([]UserGameHistoryResp, request.UserGameHistoryParam, error) {
@@ -43,16 +45,15 @@ func (c *Contract) GetUserGameHistories(db *pgxpool.Pool, ctx context.Context, u
 		paramQuery []interface{}
 		totalData  int
 		// where      []string
-
 		query = `select
 					gdata.user_id,
-					u.user_code ,
+					u.user_code,
 					gdata.game_id,
 					g."name" as game_name,
 					g.image_url as game_image_url,
 					g.duration as game_duration,
 					g.difficulty as game_difficulty,
-					g.game_type ,
+					g.game_type,
 					gdata.player_slot,
 					gdata.game_master_id,
 					a.admin_code as game_master_code,
@@ -75,7 +76,6 @@ func (c *Contract) GetUserGameHistories(db *pgxpool.Pool, ctx context.Context, u
 	)
 
 	paramQuery = append(paramQuery, userCode)
-
 	{
 		newQcount := `SELECT COUNT(*) FROM ( ` + query + ` ) AS data`
 		err := db.QueryRow(ctx, newQcount, paramQuery...).Scan(&totalData)
@@ -95,10 +95,8 @@ func (c *Contract) GetUserGameHistories(db *pgxpool.Pool, ctx context.Context, u
 	// Limit and Offset
 	param.Offset = (param.Page - 1) * param.Limit
 	query += " ORDER BY " + param.Order + " " + param.Sort + " "
-
 	paramQuery = append(paramQuery, param.Offset)
 	query += fmt.Sprintf("offset $%d ", len(paramQuery))
-
 	paramQuery = append(paramQuery, param.Limit)
 	query += fmt.Sprintf("limit $%d ", len(paramQuery))
 
@@ -154,32 +152,32 @@ func (c *Contract) GetUsersHavePlayedGameHistory(db *pgxpool.Pool, ctx context.C
 		err       error
 		list      []UsersHavePlayedGameHistoryEnt
 		totalData int64
+		query     = `WITH 
+		unique_participants AS (
+				SELECT DISTINCT r.game_id, rp.user_id, rp.created_date
+				FROM rooms r 
+				INNER JOIN rooms_participants rp ON r.id = rp.room_id AND rp.status = 'active'
+				UNION
+				SELECT DISTINCT t.game_id, tp.user_id, tp.created_date
+				FROM tournaments t
+				INNER JOIN tournament_participants tp ON t.id = tp.tournament_id AND tp.status = 'active'
+				UNION
+				SELECT DISTINCT game_id, user_id, created_date FROM users_game_collections
+		)
+		SELECT DISTINCT
+			g.id AS game_id, 
+			g."name" AS game_name, 
+			u.user_code, 
+			u.username, 
+			u.image_url AS user_image,
+			up.	created_date
+		FROM unique_participants up
 
-		query = `SELECT 
-				     games.id AS game_id, 
-				     games."name" AS game_name, 
-				     COALESCE(u.user_code, u2.user_code) AS user_code, 
-				     COALESCE(u.username, u2.username) AS username, 
-				     COALESCE(u.image_url, u2.image_url) AS user_image 
-				 FROM 
-				     games
-				 INNER JOIN 
-				     rooms ON rooms.game_id = games.id
-				 INNER JOIN 
-				     rooms_participants rp ON rp.room_id = rooms.id AND rp.status = 'active'
-				 INNER JOIN 
-				     tournaments t ON t.game_id = games.id
-				 INNER JOIN 
-				     tournament_participants tp ON tp.tournament_id = t.id AND tp.status = 'active'
-				 INNER JOIN 
-				     users u ON u.id = tp.user_id
-				 INNER JOIN 
-				     users u2 ON u2.id = rp.user_id
-				 WHERE 
-				     games.game_code = $1
-				 GROUP BY 
-				     games.id, games."name", COALESCE(u.user_code, u2.user_code), COALESCE(u.username, u2.username), COALESCE(u.image_url, u2.image_url)
-				 `
+		LEFT JOIN users as u ON up.user_id = u.id
+
+		LEFT JOIN games as g ON up.game_id = g.id 
+		WHERE g.game_code = $1
+		`
 	)
 
 	// Count total records
@@ -189,19 +187,17 @@ func (c *Contract) GetUsersHavePlayedGameHistory(db *pgxpool.Pool, ctx context.C
 		return list, totalData, c.errHandler("model.GetUserGameHistorys", err, utils.ErrCountingListUserGameHistory)
 	}
 
-	query += `ORDER BY username ASC LIMIT 3`
-
+	query += `ORDER BY up.created_date desc LIMIT 3`
 	// Execute query
 	rows, err := db.Query(ctx, query, gameCode)
 	if err != nil {
 		return list, totalData, c.errHandler("model.GetUserGameHistories", err, utils.ErrGettingListUserGameHistory)
 	}
 	defer rows.Close()
-
 	// Process results
 	for rows.Next() {
 		var data UsersHavePlayedGameHistoryEnt
-		err = rows.Scan(&data.GameId, &data.GameName, &data.UserCode, &data.UserName, &data.UserImage)
+		err = rows.Scan(&data.GameId, &data.GameName, &data.UserCode, &data.UserName, &data.UserImage, &data.CreatedDate)
 		if err != nil {
 			return list, totalData, c.errHandler("model.GetUserGameHistories", err, utils.ErrScanningListUserGameHistory)
 		}

--- a/services/api/request/game.go
+++ b/services/api/request/game.go
@@ -24,6 +24,7 @@ type (
 		MinimalParticipant int64             `json:"minimal_participant"`
 		MaximumParticipant int64             `json:"maximum_participant" validate:"required"`
 		AdminCode          string            `json:"admin_code"`
+		AdminCodes         []string          `json:"admin_codes"`
 		GameCategories     []GameCategoryReq `json:"game_categories"`
 	}
 
@@ -94,7 +95,7 @@ func (param *GameParam) ParseGame(values url.Values) error {
 
 	if status, ok := values["status"]; ok && len(status) > 0 {
 		if !utils.Contains(utils.StatusGame, status[0]) {
-			return fmt.Errorf("%s", "wrong status value for game(active|inactive)")
+			return fmt.Errorf("%s", "wrong status value for game(active|inactive")
 		}
 		param.Status = status[0]
 	}

--- a/services/api/response/game.go
+++ b/services/api/response/game.go
@@ -22,7 +22,7 @@ type GameRes struct {
 	GameCategories     []GameCategoryRes      `json:"game_categories"`
 	GameRelated        []GameRelatedRes       `json:"game_related"`
 	GameRooms          []GameAvailableRoomRes `json:"game_rooms"`
-	GameMasters        AdminRes               `json:"game_masters"`
+	GameMasters        []AdminRes             `json:"game_masters"`
 	NumberOfPopularity int64                  `json:"number_of_popularity"`
 }
 
@@ -37,6 +37,7 @@ type GameDetailRes struct {
 	CollectionUrl             []string                        `json:"collection_url"`
 	Description               string                          `json:"description"`
 	Status                    string                          `json:"status"`
+	NumberOfPopularity        int64                           `json:"number_of_popularity"`
 	Difficulty                string                          `json:"difficulty"`
 	Level                     float64                         `json:"level"`
 	Duration                  int64                           `json:"duration"`
@@ -46,18 +47,18 @@ type GameDetailRes struct {
 	GameCategories            []GameCategoryRes               `json:"game_categories"`
 	GameRelated               []GameRelatedRes                `json:"game_related"`
 	GameRooms                 []GameAvailableRoomRes          `json:"game_rooms"`
-	GameMasters               AdminRes                        `json:"game_masters"`
+	GameMasters               []AdminRes                      `json:"game_masters"`
 	UserHavePlayedGameHistory []UsersHavePlayedGameHistoryRes `json:"user_have_played_game_history"`
 	TotalPlayer               int64                           `json:"total_player"`
-	IsPopular                 bool                            `json:"is_popular"`
 }
 
 type UsersHavePlayedGameHistoryRes struct {
-	GameId    int64  `json:"game_id"`
-	GameName  string `json:"game_name"`
-	UserCode  string `json:"user_code"`
-	UserName  string `json:"username"`
-	UserImage string `json:"user_image"`
+	GameId      int64  `json:"game_id"`
+	GameName    string `json:"game_name"`
+	UserCode    string `json:"user_code"`
+	UserName    string `json:"username"`
+	UserImage   string `json:"user_image"`
+	CreatedDate string `json:"created_date,omitempty"`
 }
 
 type GameQRCodeRes struct {


### PR DESCRIPTION
1. Multiple Game Master in game catalog, previously only one game master can be added to game catalog.
2. Adjust monthly unique user 
- to include count data from game collection
- filter by range less than equal by year-month
3. Add/Adjust user history that played the game in game detail